### PR TITLE
Better filenames

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,8 +123,8 @@ func toDownloadPath(videoURL string, downloadDir string) string {
 	if strings.HasPrefix(u.Path, "/watch") && u.Query().Has("trackId") {
 		videoId := strings.TrimLeft(u.Path, "/watch/")
 		trackId := u.Query().Get("trackId")
-		return downloadDir + "/" + videoId + "-" + trackId + "-" + strconv.Itoa(rand.Int())
+		return downloadDir + "/" + videoId + "-" + trackId + "-" + strconv.Itoa(rand.Int()) + ".mp4a"
 	}
 
-	return downloadDir + "/" + "DL-" + strconv.Itoa(rand.Int())
+	return downloadDir + "/" + "DL-" + strconv.Itoa(rand.Int()) + ".mp4a"
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/stretchr/testify/assert"
-	"os"
 	"strings"
 	"testing"
 )
@@ -11,12 +10,20 @@ func TestToDownloadPath(t *testing.T) {
 	downloadDir := "/tmp/foo"
 
 	videoUrl := "https://www.netflix.com/watch/81405170?trackId=254015180"
-	downloadPath := toDownloadPath(videoUrl, downloadDir)
+	downloadPath := toDownloadPath(videoUrl, downloadDir, probeInfo{
+		isAudio:    true,
+		majorBrand: "mp42",
+		isXHEAAC:   false,
+	})
 	assert.True(t, strings.HasPrefix(downloadPath, "/tmp/foo/81405170-254015180-"))
 	assert.True(t, strings.HasSuffix(downloadPath, ".mp4a"))
 
 	videoUrl = "https://www.netflix.com"
-	downloadPath = toDownloadPath(videoUrl, downloadDir)
+	downloadPath = toDownloadPath(videoUrl, downloadDir, probeInfo{
+		isAudio:    true,
+		majorBrand: "mp42",
+		isXHEAAC:   false,
+	})
 	assert.True(t, strings.HasPrefix(downloadPath, "/tmp/foo/DL-"))
 	assert.True(t, strings.HasSuffix(downloadPath, ".mp4a"))
 }
@@ -25,28 +32,4 @@ func TestToDownloadableURL(t *testing.T) {
 	mediaURL := "https://ipv6-cndoca-avcd.nflxvideo.net/range/0-52342?t=12345"
 	downloadableURL := toDownloadableURL(mediaURL)
 	assert.Equal(t, "https://ipv6-cndoca-avcd.nflxvideo.net?t=12345", downloadableURL)
-}
-
-func TestProbeFileFormat(t *testing.T) {
-	testCases := []struct {
-		filePath string
-		isAudio  bool
-	}{
-		{"test/testdata/audio_iso6.mp4", true},
-		{"test/testdata/audio_mp42.mp4", true},
-		{"test/testdata/vid.mp4", false},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.filePath, func(t *testing.T) {
-			data, err := os.ReadFile(tc.filePath)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			isAudio, err := probeFileFormat(data)
-			assert.Nil(t, err)
-			assert.Equal(t, tc.isAudio, isAudio)
-		})
-	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -13,10 +13,12 @@ func TestToDownloadPath(t *testing.T) {
 	videoUrl := "https://www.netflix.com/watch/81405170?trackId=254015180"
 	downloadPath := toDownloadPath(videoUrl, downloadDir)
 	assert.True(t, strings.HasPrefix(downloadPath, "/tmp/foo/81405170-254015180-"))
+	assert.True(t, strings.HasSuffix(downloadPath, ".mp4a"))
 
 	videoUrl = "https://www.netflix.com"
 	downloadPath = toDownloadPath(videoUrl, downloadDir)
 	assert.True(t, strings.HasPrefix(downloadPath, "/tmp/foo/DL-"))
+	assert.True(t, strings.HasSuffix(downloadPath, ".mp4a"))
 }
 
 func TestToDownloadableURL(t *testing.T) {

--- a/probe.go
+++ b/probe.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"github.com/abema/go-mp4"
+)
+
+type probeInfo struct {
+	isAudio    bool
+	majorBrand string
+	isXHEAAC   bool
+}
+
+// probeFileFormat reads the header of file and checks if it is an audio file and returns some info about it.
+func probeFileFormat(header []byte) (isAudio bool, pInfo probeInfo, err error) {
+	const xHE_AAC_AudOTI = 42 //  Audio Object Type Identifier (OTI) for xHE-AAC
+
+	pi := probeInfo{}
+
+	info, err := mp4.Probe(bytes.NewReader(header))
+	if err != nil {
+		return false, pi, err
+	}
+
+	majorBrand := string(info.MajorBrand[:])
+
+	// On macOS xHE-AAC is delivered (sometimes?) in an iso6 container
+	if (majorBrand == "mp42" || majorBrand == "iso6") && len(info.Tracks) == 1 && info.Tracks[0].Codec == mp4.CodecMP4A {
+		pi.isAudio = true
+		pi.isXHEAAC = info.Tracks[0].MP4A.AudOTI == xHE_AAC_AudOTI
+		pi.majorBrand = majorBrand
+	}
+
+	return pi.isAudio, pi, nil
+}

--- a/probe_test.go
+++ b/probe_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestProbeFileFormat_IsAudio(t *testing.T) {
+	testCases := []struct {
+		filePath string
+		isAudio  bool
+	}{
+		{"test/testdata/audio_iso6.mp4", true},
+		{"test/testdata/audio_mp42.mp4", true},
+		{"test/testdata/vid.mp4", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.filePath, func(t *testing.T) {
+			data, err := os.ReadFile(tc.filePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			isAudio, _, err := probeFileFormat(data)
+			assert.Nil(t, err)
+			assert.Equal(t, tc.isAudio, isAudio)
+		})
+	}
+}
+
+func TestProbeFileFormat_Info(t *testing.T) {
+	data, err := os.ReadFile("test/testdata/audio_iso6.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, info, err := probeFileFormat(data)
+
+	assert.NoError(t, err)
+	assert.Equal(t, true, info.isXHEAAC)
+	assert.Equal(t, "iso6", info.majorBrand)
+	assert.Equal(t, true, info.isAudio)
+
+	data, err = os.ReadFile("test/testdata/audio_mp42.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, info, err = probeFileFormat(data)
+
+	assert.NoError(t, err)
+	assert.Equal(t, false, info.isXHEAAC)
+	assert.Equal(t, "mp42", info.majorBrand)
+	assert.Equal(t, true, info.isAudio)
+
+	data, err = os.ReadFile("test/testdata/vid.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, info, err = probeFileFormat(data)
+
+	assert.NoError(t, err)
+	assert.Equal(t, false, info.isAudio)
+
+}


### PR DESCRIPTION
- Use .mp4a extension for downloaded files
- Add codec to file name i.e ``foo-bar-xxx.aac.mp4a`` of ``baz-qux-xxx.xhe-aac.mp4a`
